### PR TITLE
Update Networking for GameObjects to 1.8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,16 @@ Leveraging Unity's [Netcode for GameObjects](https://github.com/Unity-Technologi
 
 ### NetworkStateManager
 
-1. Install using OpenUPM by visiting the [package's page](https://openupm.com/packages/com.github.xaroth8088.networkstatemanager/) and following the installation instructions there.
-  - NOTE: I'm having some difficulty getting this to work cleanly.  Please reach out in Issues if you'd like a workaround in the meantime.
-2. Add a new `GameObject` to your scene and attach the `NetworkStateManager` script to it.
-3. When your scene is fully loaded, call `StartNetworkManager()` with the runtime-determined types of your game state objects (see "State management", below), like so:
+1. Install prerequisites:
+  - In Unity, open Package Manager
+  - Click the `+` button in the top left, and select `Install package from Git URL...`
+  - Paste `https://github.com/Cysharp/MemoryPack.git?path=src/MemoryPack.Unity/Assets/Plugins/MemoryPack#1.10.0` and click `Install`
+2. Install NetworkStateManager:
+  - In Unity, open Package Manager
+  - Click the `+` button in the top left, and select `Install package from Git URL...`
+  - Paste `https://github.com/xaroth8088/NetworkStateManager.git` and click `Install`
+3. Add a new `GameObject` to your scene and attach the `NetworkStateManager` script to it.
+4. When your scene is fully loaded, call `StartNetworkManager()` with the runtime-determined types of your game state objects (see "State management", below), like so:
 
 ```C#
 // Grab the NetworkStateManager instance
@@ -129,12 +135,6 @@ Then, every frame that needs to be projected forwards is run via these events:
 `OnPrePhysicsFrameUpdate`
 `OnPostPhysicsFrameUpdate`
 `OnGetGameState`
-
-## Why OpenUPM for package installation?
-
-Starting with version 0.0.5, NSM relies on additional open-source libraries.  However, Unity doesn't have a public repo system for their package manager the way, say, `npm` exists for JavaScript development, and - even more frustratingly - their pacakage manager doesn't allow custom packages to depend on git repos, even though top-level packages _can_ be installed via git.
-
-OpenUPM solves this issue by hosting their own public repo and hiding away all the Unity garbage that needs to happen in order for dependencies like this to work.
 
 ## How can I help this project?
 

--- a/Runtime/NetworkStateManager.cs
+++ b/Runtime/NetworkStateManager.cs
@@ -500,8 +500,8 @@ namespace NSM
 
         // TODO: prevent a client from sending input for a player they shouldn't be sending input for
         // NOTE: Rpc's are processed at the _end_ of each frame
-        [ServerRpc(RequireOwnership = false)]
-        private void SetPlayerInputsServerRpc(PlayerInputsDTO playerInputs, int clientTimeTick, ServerRpcParams serverRpcParams = default)
+        [Rpc(SendTo.Server, RequireOwnership = false)]
+        private void SetPlayerInputsServerRpc(PlayerInputsDTO playerInputs, int clientTimeTick)
         {
             if (!isRunning)
             {
@@ -530,8 +530,8 @@ namespace NSM
         }
 
         // NOTE: Rpc's are processed at the _end_ of each frame
-        [ServerRpc(RequireOwnership = false)]
-        private void RequestFullStateUpdateServerRpc(ServerRpcParams serverRpcParams = default)
+        [Rpc(SendTo.Server, RequireOwnership = false)]
+        private void RequestFullStateUpdateServerRpc(RpcParams rpcParams = default)
         {
             VerboseLog("Received request for full state update");
 
@@ -541,7 +541,7 @@ namespace NSM
             VerboseLog("Full frame requested for " + requestedGameTick);
 
             // Send this back to only the client that requested it
-            ProcessFullStateUpdateClientRpc(stateBuffer[requestedGameTick], gameEventsBuffer, realGameTick, RpcTarget.Single(serverRpcParams.Receive.SenderClientId, RpcTargetUse.Temp));
+            ProcessFullStateUpdateClientRpc(stateBuffer[requestedGameTick], gameEventsBuffer, realGameTick, RpcTarget.Single(rpcParams.Receive.SenderClientId, RpcTargetUse.Temp));
         }
 
         #endregion Server-side only code

--- a/Runtime/RigidBodyStateDTO.cs
+++ b/Runtime/RigidBodyStateDTO.cs
@@ -18,7 +18,7 @@ namespace NSM
         {
             position = rigidbody.gameObject.transform.position;
             rotation = rigidbody.gameObject.transform.rotation;
-            velocity = rigidbody.velocity;
+            velocity = rigidbody.linearVelocity;
             angularVelocity = rigidbody.angularVelocity;
             isSleeping = rigidbody.IsSleeping();
 
@@ -48,7 +48,7 @@ namespace NSM
 
             if (rigidbody.isKinematic == false)
             {
-                rigidbody.velocity = velocity;
+                rigidbody.linearVelocity = velocity;
                 rigidbody.angularVelocity = angularVelocity;
             }
         }

--- a/Runtime/StateBuffer.cs
+++ b/Runtime/StateBuffer.cs
@@ -33,7 +33,17 @@ namespace NSM
 
                 if (_stateBuffer.ContainsKey(i) && _stateBuffer[i].authoritative)
                 {
-                    Debug.LogError("Tried to overwrite an authoritative frame at tick " + i);
+                    Debug.LogWarning($"Tried to overwrite an authoritative frame at tick {i}.  This can happen in certain edge-cases, and is probably not a cause for concern.");
+                    // Specifically, the edge-case in question looks like this:
+                    //      Server sends out its normal delta update
+                    //      Server receives input from some client that's timestamped from before the delta update
+                    //      Server rewinds and replays, then sends the input to all clients
+                    //      Due to network conditions, the delta and input update both arrive _in the same frame_ on the client that's showing this error
+                    //      The client runs the delta update, marking the frame as authoritative
+                    //      The client runs the input update (again, timestamped from before the delta's timestamp), and wants to update the authoritative frame
+                    //      This warning condition is triggered
+
+                    // TODO: there's gotta be a better way to handle this
                 }
                 _stateBuffer[i] = value;
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.github.xaroth8088.networkstatemanager",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "A framework to add server-authoritative, client-predictive physics to Unity",
   "displayName": "NetworkStateManager",
   "unity": "2022.3",
@@ -10,8 +10,7 @@
   },
   "changelogUrl": "https://github.com/xaroth8088/NetworkStateManager/blob/main/CHANGELOG.md",
   "dependencies": {
-    "com.unity.netcode.gameobjects": "1.6.0",
-    "com.cysharp.memorypack": "https://github.com/Cysharp/MemoryPack.git?path=src/MemoryPack.Unity/Assets/Plugins/MemoryPack#1.9.14"
+    "com.unity.netcode.gameobjects": "1.8.1"
   },
   "documentationUrl": "https://github.com/xaroth8088/NetworkStateManager",
   "keywords": ["physics", "networking", "client-side prediction"],


### PR DESCRIPTION
Also includes these minor updates:
* Use `linearVelocity` instead of `velocity` for rigidbody state
* Update `README` with better installation instructions
* Change an edge-case's message from "error" to "warning", because this case happens much more frequently with the current version of NGO, and isn't that big of a problem (the state will auto-heal via a full state refresh when needed)